### PR TITLE
fix: multi dimension update for covariance in gmm

### DIFF
--- a/gmm/gmm.py
+++ b/gmm/gmm.py
@@ -120,7 +120,7 @@ class GMM(object):
             mu_c = self.mu[c, :]
             n_c = denoms[c]
 
-            outer = np.zeros((2, 2))
+            outer = np.zeros((self.d, self.d))
             for i in range(N):
                 wic = self.Q[i, c]
                 xi = self.X[i, :]


### PR DESCRIPTION
**- What bug I fixed**

According to @jjjjohnson in #16 , we can apply multi dimension covariance in gmm.

This pull request fixes #16.

**- How I fixed it**

1. `change` dimension from `2` to `self.d`.

**- How you can verify it**

The tests did not pass because of the following:
And tests did pass before changing. We can ask @jjjjohnson to take a look.

```
/Users/zhuoran/Documents/git/numpy-ml/gmm/gmm.py:66: RuntimeWarning: invalid value encountered in double_scalars
  if np.isnan(vlb) or np.abs((vlb - prev_vlb) / prev_vlb) <= tol:
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
Singular matrix: components collapsed
Components collapsed; Refitting
/Users/zhuoran/Documents/git/numpy-ml/gmm/gmm.py:116: RuntimeWarning: invalid value encountered in true_divide
  self.mu[ix, :] = num / den
/Users/zhuoran/Documents/git/numpy-ml/gmm/gmm.py:43: RuntimeWarning: divide by zero encountered in log
  log_pi_k = np.log(pi_k)
/usr/local/lib/python3.7/site-packages/numpy/linalg/linalg.py:1817: RuntimeWarning: invalid value encountered in slogdet
  sign, logdet = _umath_linalg.slogdet(a, signature=signature)
Singular matrix: components collapsed
Components collapsed; Refitting
Traceback (most recent call last):
  File "/Users/zhuoran/Documents/git/numpy-ml/gmm/tests.py", line 111, in <module>
    plot()
  File "/Users/zhuoran/Documents/git/numpy-ml/gmm/tests.py", line 100, in plot
    ax = plot_clusters(G, X, ax)
  File "/Users/zhuoran/Documents/git/numpy-ml/gmm/tests.py", line 52, in plot_clusters
    rv = multivariate_normal(model.mu[c], model.sigma[c], allow_singular=True)
  File "/usr/local/lib/python3.7/site-packages/scipy/stats/_multivariate.py", line 363, in __call__
    seed=seed)
  File "/usr/local/lib/python3.7/site-packages/scipy/stats/_multivariate.py", line 736, in __init__
    self.cov_info = _PSD(self.cov, allow_singular=allow_singular)
  File "/usr/local/lib/python3.7/site-packages/scipy/stats/_multivariate.py", line 156, in __init__
    s, u = scipy.linalg.eigh(M, lower=lower, check_finite=check_finite)
  File "/usr/local/lib/python3.7/site-packages/scipy/linalg/decomp.py", line 374, in eigh
    a1 = _asarray_validated(a, check_finite=check_finite)
  File "/usr/local/lib/python3.7/site-packages/scipy/_lib/_util.py", line 239, in _asarray_validated
    a = toarray(a)
  File "/usr/local/lib/python3.7/site-packages/numpy/lib/function_base.py", line 1233, in asarray_chkfinite
    "array must not contain infs or NaNs")
ValueError: array must not contain infs or NaNs
```