### PR TITLE
More efficient second derivative sigmoid function

### DIFF
--- a/neural_nets/activations/activations.py
+++ b/neural_nets/activations/activations.py
@@ -39,7 +39,7 @@ class Sigmoid(ActivationBase):
         return self.fn(x) * (1 - self.fn(x))
 
     def grad2(self, x):
-        return self.grad(x) * (1 - self.fn(x)) - self.fn(x) * self.grad(x)
+        return self.grad(x) * (1 - 2 * self.fn(x))
 
 
 class ReLU(ActivationBase):


### PR DESCRIPTION
Modified grad2 function for the Sigmoid activation to be more efficient.

Now it only calculates self.grad once in the entire calculation and is ~2x faster (tested).