### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/numpy_ml/neural_nets/layers/layers.py
+++ b/numpy_ml/neural_nets/layers/layers.py
@@ -1842,10 +1842,10 @@ class Embedding(LayerBase):
         if self.pool is None:
             for ix, v_id in enumerate(X.flatten()):
                 dW[v_id] += dLdy[ix]
-        elif self.pool is "sum":
+        elif self.pool == "sum":
             for ix, v_ids in enumerate(X):
                 dW[v_ids] += dLdy[ix]
-        elif self.pool is "mean":
+        elif self.pool == "mean":
             for ix, v_ids in enumerate(X):
                 dW[v_ids] += dLdy[ix] / len(v_ids)
         return dW


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

### All Submissions

* [x] Is the code you are submitting your own work?
* [ ] Have you followed the [contributing guidelines](https://github.com/ddbourgin/numpy-ml/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ddbourgin/numpy-ml/pulls) for the same update/change?

### New Model Submissions

* [ ] Is the code you are submitting your own work?
* [ ] Did you properly attribute the authors of any code you referenced?
* [ ] Did you write unit tests for your new model?
* [ ] Does your submission pass the unit tests?
* [ ] Did you write documentation for your new model?
* [ ] Have you formatted your code using the [black](https://black.now.sh/) deaults?

### Changes to Existing Models

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
