### PR TITLE
Bugfix: pass through vocab/encoding params

### DIFF
--- a/numpy_ml/ngram/ngram.py
+++ b/numpy_ml/ngram/ngram.py
@@ -506,7 +506,7 @@ class GoodTuringNGram(NGramBase):
             Specifies the text encoding for corpus. Common entries are 'utf-8',
             'utf-8-sig', 'utf-16'. Default is None.
         """
-        self._train(corpus_fp, vocab=None, encoding=None)
+        self._train(corpus_fp, vocab=vocab, encoding=encoding)
         self._calc_smoothed_counts()
 
     def log_prob(self, words, N):


### PR DESCRIPTION
This appears to be a typo. I think the correct behavior is that GoodTuring should take into account a vocab and encoding if given.

Side note: How do you run the tests in this repo?

I tried evaluating `tests/test_ngram.py` in a REPL but got an error about `attempted relative import with no known parent package`. I tried running `python -m unittest` but got a `ModuleNotFoundError: No module named 'librosa.core.time_frequency'`. I resorted to `python -c 'from numpy_ml.tests import test_ngram; test_ngram.some_test()`. Noting that there's not a test for GoodTuring yet.