### PR TITLE
Compatibility with librosa>=0.8.0

### DIFF
--- a/numpy_ml/tests/test_preprocessing.py
+++ b/numpy_ml/tests/test_preprocessing.py
@@ -10,7 +10,11 @@ from scipy.fftpack import dct
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import TfidfVectorizer
 
-from librosa.core.time_frequency import fft_frequencies
+try:
+    from librosa.core.time_frequency import fft_frequencies
+except ImportError:
+    # for librosa >= 0.8.0
+    from librosa import fft_frequencies
 from librosa.feature import mfcc as lr_mfcc
 from librosa.util import frame
 from librosa.filters import mel

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,7 @@ tensorflow
 keras
 gym
 huffman
-librosa
+librosa>=0.8.0
 nltk
 hmmlearn
 tox


### PR DESCRIPTION
To be able to run the tests with the latest version of librosa, you need this adjustement.