### PR TITLE
Added support for Online Linear Regression

### DIFF
--- a/numpy_ml/linear_models/README.md
+++ b/numpy_ml/linear_models/README.md
@@ -1,7 +1,7 @@
 # Linear Models
 The `lm.py` module implements:
 
-1. [OLS linear regression](https://en.wikipedia.org/wiki/Ordinary_least_squares) with maximum likelihood parameter estimates via the normal equation.
+1. [OLS linear regression](https://en.wikipedia.org/wiki/Ordinary_least_squares) with maximum likelihood parameter estimates via the normal equation. For both (Online and Batch mode)
 2. [Ridge regression / Tikhonov regularization](https://en.wikipedia.org/wiki/Tikhonov_regularization)
    with maximum likelihood parameter estimates via the normal equation.
 2. [Logistic regression](https://en.wikipedia.org/wiki/Logistic_regression) with maximum likelihood parameter estimates via gradient descent.

--- a/numpy_ml/linear_models/lm.py
+++ b/numpy_ml/linear_models/lm.py
@@ -11,54 +11,87 @@ class LinearRegression:
 
         Notes
         -----
-        Given data matrix *X* and target vector *y*, the maximum-likelihood estimate
-        for the regression coefficients, :math:`\\beta`, is:
+        Given data matrix **X** and target vector **y**, the maximum-likelihood
+        estimate for the regression coefficients, :math:`\beta`, is:
 
         .. math::
 
-            \hat{\beta} =
-                \left(\mathbf{X}^\top \mathbf{X}\right)^{-1} \mathbf{X}^\top \mathbf{y}
+            \hat{\beta} = \Sigma^{-1} \mathbf{X}^\top \mathbf{y}
+
+        where :math:`\Sigma^{-1} = (\mathbf{X}^\top \mathbf{X})^{-1}`.
 
         Parameters
         ----------
         fit_intercept : bool
-            Whether to fit an additional intercept term in addition to the
-            model coefficients. Default is True.
+            Whether to fit an intercept term in addition to the model
+            coefficients. Default is True.
         """
         self.beta = None
+        self.sigma_inv = None
         self.fit_intercept = fit_intercept
-        self.inverse_cov = None
+
+        self._is_fit = False
 
     def update(self, x, y):
-        """
-        Incrementally update the regression coefficients using Matrix Inversion Lemma RLS, version 1 ( https://github.com/ddbourgin/numpy-ml/files/6536069/rls.pdf ).
+        r"""
+        Incrementally update the least-squares coefficients on a new example
+        via recursive least-squares (RLS) [1]_ .
+
+        Notes
+        -----
+        The RLS algorithm [2]_ is used to efficiently update the regression
+        parameters as new examples become available. For a new example
+        :math:`(\mathbf{x}_{t+1}, \mathbf{y}_{t+1})`, the parameter updates are
+
+        .. math::
+
+            \beta_{t+1} = \left(
+                \mathbf{X}_{1:t}^\top \mathbf{X}_{1:t} +
+                    \mathbf{x}_{t+1}\mathbf{x}_{t+1}^\top \right)^{-1}
+                        \mathbf{X}_{1:t}^\top \mathbf{Y}_{1:t} +
+                            \mathbf{x}_{t+1}^\top \mathbf{y}_{t+1}
+
+        where :math:`\beta_{t+1}` are the updated regression coefficients,
+        :math:`\mathbf{X}_{1:t}` and :math:`\mathbf{Y}_{1:t}` are the set of
+        examples observed from timestep 1 to *t*.
+
+        To perform the above update efficiently, the RLS algorithm makes use of
+        the Sherman-Morrison formula [3]_ to avoid re-inverting the covariance
+        matrix on each new update.
+
+        References
+        ----------
+        .. [1] Gauss, C. F. (1821) _Theoria combinationis observationum
+           erroribus minimis obnoxiae_, Werke, 4. Gottinge
+        .. [2] https://en.wikipedia.org/wiki/Recursive_least_squares_filter
+        .. [3] https://en.wikipedia.org/wiki/Sherman%E2%80%93Morrison_formula
 
         Parameters
         ----------
-        x : :py:class:`ndarray <numpy.ndarray>` of shape `(N, M)` on first attempt and shape (1, M) on subsequent updates
-            A dataset consisting of `N` examples, each of dimension `M`.
-        y : :py:class:`ndarray <numpy.ndarray>` of shape `(N, K)` on first attempt and shape (1, K) on subsequent updates
-            The targets for each of the `N` examples in `X`, where each target
-            has dimension `K`.
+        x : :py:class:`ndarray <numpy.ndarray>` of shape `(1, M)`
+            A single example of rank `M`
+        y : :py:class:`ndarray <numpy.ndarray>` of shape `(1, K)`
+            A `K`-dimensional target vector for the current example
         """
-        xm = np.mat(x)
-        ym = np.mat(y)
-
-        if self.fit_intercept:
-            xm = np.c_[np.ones(xm.shape[0]), xm]
-
-        all_zeros_or_empty_inverse_cov = not np.any(self.inverse_cov)
-        all_zeros_or_empty_beta = not np.any(self.beta)
-
-        if all_zeros_or_empty_inverse_cov or all_zeros_or_empty_beta: # first run of the algorithm
+        if not self._is_fit:
             raise RuntimeError("You must call the `fit` method before calling `update`")
-        else:
-            # Allow only single row vectors or column vectors as input
-            theta_xm = np.mat (xm * self.beta)
-            error = ym - theta_xm
-            Im = np.mat(np.eye (xm.shape[1]))
-            self.inverse_cov = self.inverse_cov * np.mat(Im - ((xm.T * xm * self.inverse_cov) / (1 + (xm * self.inverse_cov * xm.T))))
-            self.beta = self.beta + (self.inverse_cov * xm.T * error)
+
+        x, y = np.atleast_2d(x), np.atleast_2d(y)
+        beta, S_inv = self.beta, self.sigma_inv
+
+        X1, Y1 = x.shape[0], y.shape[0]
+        err_str = f"First dimension of x and y must be 1, but got {X1} and {Y1}"
+        assert X1 == Y1 == 1, err_str
+
+        # convert x to a design vector if we're fitting an intercept
+        if self.fit_intercept:
+            x = np.c_[1, x]
+
+        # update the inverse of the covariance matrix via Sherman-Morrison
+        S_inv -= (S_inv @ x.T @ x @ S_inv) / (1 + x @ S_inv @ x.T)
+
+        # update the model coefficients
+        beta += S_inv @ x.T @ (y - x @ beta)
 
     def fit(self, X, y):
         """
@@ -76,8 +109,10 @@ class LinearRegression:
         if self.fit_intercept:
             X = np.c_[np.ones(X.shape[0]), X]
 
-        pseudo_inverse = np.linalg.inv(X.T @ X) @ X.T
-        self.beta = np.dot(pseudo_inverse, y)
+        self.sigma_inv = np.linalg.pinv(X.T @ X)
+        self.beta = np.atleast_2d(self.sigma_inv @ X.T @ y)
+
+        self._is_fit = True
 
     def predict(self, X):
         """
@@ -198,22 +233,22 @@ class LogisticRegression:
                 \left(
                     \sum_{i=0}^N y_i \log(\hat{y}_i) +
                       (1-y_i) \log(1-\hat{y}_i)
-                \right) - R(\mathbf{b}, \gamma) 
+                \right) - R(\mathbf{b}, \gamma)
             \right]
-        
+
         where
-        
+
         .. math::
-        
+
             R(\mathbf{b}, \gamma) = \left\{
                 \begin{array}{lr}
                     \frac{\gamma}{2} ||\mathbf{beta}||_2^2 & :\texttt{ penalty = 'l2'}\\
                     \gamma ||\beta||_1 & :\texttt{ penalty = 'l1'}
                 \end{array}
                 \right.
-                
-        is a regularization penalty, :math:`\gamma` is a regularization weight, 
-        `N` is the number of examples in **y**, and **b** is the vector of model 
+
+        is a regularization penalty, :math:`\gamma` is a regularization weight,
+        `N` is the number of examples in **y**, and **b** is the vector of model
         coefficients.
 
         Parameters
@@ -283,10 +318,10 @@ class LogisticRegression:
             \right]
         """
         N, M = X.shape
-        beta, gamma = self.beta, self.gamma 
+        beta, gamma = self.beta, self.gamma
         order = 2 if self.penalty == "l2" else 1
         norm_beta = np.linalg.norm(beta, ord=order)
-        
+
         nll = -np.log(y_pred[y == 1]).sum() - np.log(1 - y_pred[y == 0]).sum()
         penalty = (gamma / 2) * norm_beta ** 2 if order == 2 else gamma * norm_beta
         return (penalty + nll) / N

--- a/numpy_ml/linear_models/lm.py
+++ b/numpy_ml/linear_models/lm.py
@@ -51,10 +51,7 @@ class LinearRegression:
         all_zeros_or_empty_beta = not np.any(self.beta)
 
         if all_zeros_or_empty_inverse_cov or all_zeros_or_empty_beta: # first run of the algorithm
-            # Allow a batch of data in a matrix form as input
-            self.inverse_cov = np.linalg.pinv(np.dot(xm.T, xm)) # avoid non-invertible cases
-            pseudo_inverse =  np.dot(self.inverse_cov, xm.T)
-            self.beta = np.dot(pseudo_inverse, ym.T)
+            raise RuntimeError("You must call the `fit` method before calling `update`")
         else:
             # Allow only single row vectors or column vectors as input
             theta_xm = np.mat (xm * self.beta)

--- a/numpy_ml/tests/test_linear_regression.py
+++ b/numpy_ml/tests/test_linear_regression.py
@@ -1,0 +1,41 @@
+import numpy as np
+from numpy_ml.linear_models.lm import LinearRegression
+from sklearn import datasets
+from sklearn.datasets.samples_generator import make_blobs
+from sklearn.linear_model import LinearRegression as OriginalLinearRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import r2_score
+
+def test_linear_model(N=1):
+    seed = 12345
+    np.random.seed(seed)
+    n_clusters=4
+    # loading the dataset
+    orig_num_of_samples, orig_num_of_features = 3000, 300
+    X, y = make_blobs(n_samples=orig_num_of_samples, centers=n_clusters, n_features = orig_num_of_features, cluster_std=0.50, random_state=seed)
+    X_train, X_update, y_train, y_update = train_test_split(X, y, test_size=0.2, random_state=seed)
+
+    # Ground truth
+    orig_lreg_model = OriginalLinearRegression()
+    orig_lreg_model.fit(X, y)
+
+    # Our model
+    olr = LinearRegression()
+    olr.fit(X_train, y_train)
+
+    ## update our model
+    for x_new, y_new in zip(X_update, y_update):
+        x_new = x_new.reshape((1, orig_num_of_features))
+        y_new = y_new
+        olr.update(x_new, y_new)
+
+    # Evaluating
+    X_test, y_test = make_blobs(n_samples=orig_num_of_samples, centers=n_clusters, n_features = orig_num_of_features, cluster_std=0.50, random_state=seed+2)
+
+    y_pred_orig = orig_lreg_model.predict (X_test)
+    y_pred_online = olr.predict (X_test)
+
+    r2score_orig = r2_score(y_test, y_pred_orig) 
+    r2score_online = r2_score(y_test, y_pred_online) 
+    print ("Both score must be similar between scikit: {} and our own online implementation: {}".format(r2score_orig, r2score_online))
+


### PR DESCRIPTION
This work is to create an online version of Linear regression as described in issue https://github.com/ddbourgin/numpy-ml/issues/70 . The implement the online version of the Ordinary least square using Matrix Inversion Lemma RLS, version 1 ( https://github.com/ddbourgin/numpy-ml/files/6536069/rls.pdf ).

Beware that there will be trade-off in some performance during the noisy nature of training on a sample at a time, in comparison to a batch. On the average, this should not be too significant.

# To Do
### Add unit test
* [x] Is the code you are submitting your own work? Yes
* [x] Did you properly attribute the authors of any code you referenced? Yes
* [x] Did you write unit tests for your new model?
* [x] Does your submission pass the unit tests?
* [ ] Did you write documentation for your new model?
* [ ] Have you formatted your code using the [black](https://black.now.sh/) deaults?

A sample for the API call is
```
olr = LinearRegression()
olr.fit(X, y)
olr.predict(rest-x)
# on new data just call update to modify beta field and update the model in an online manner
olr.update(x_new, y_new)
```
Note: no modification has happened to existing implementation as it is only active when update method is called.


