### PR TITLE
fixed Edge.reverse()

### DIFF
--- a/numpy_ml/utils/graphs.py
+++ b/numpy_ml/utils/graphs.py
@@ -39,7 +39,7 @@ class Edge(object):
 
     def reverse(self):
         """Reverse the edge direction"""
-        return Edge(self.t, self.f, self.w)
+        return Edge(self.to, self.fr, self._w)
 
 
 #######################################################################


### PR DESCRIPTION
Fixed typos in Edge.reverse() which caused AttributeErrors: the undefined self.fr, self.to, self._w instead of the defined self.f, self.t, self.w


