### PR TITLE
Update GELU to actually use approximate parameter instead of always being set to True

### DIFF
--- a/numpy_ml/neural_nets/activations/activations.py
+++ b/numpy_ml/neural_nets/activations/activations.py
@@ -229,7 +229,7 @@ class GELU(ActivationBase):
             error function when calculating the unit activation and gradient.
             Default is True.
         """
-        self.approximate = True
+        self.approximate = approximate
         super().__init__()
 
     def __str__(self):


### PR DESCRIPTION
Update the GELU (Gaussian error linear unit) activation's init function so that self.approximate is set to the approximate parameter instead of always being set to True regardless of what the user passes in.
