### PR TITLE
Update collections import in data_structures.py

### DIFF
--- a/numpy_ml/utils/data_structures.py
+++ b/numpy_ml/utils/data_structures.py
@@ -1,6 +1,9 @@
 import heapq
 from copy import copy
-from collections import Hashable
+try:
+    from collections.abc import Hashable
+except ImportError:
+    from collections import Hashable
 
 import numpy as np
 


### PR DESCRIPTION
Updated Hashable import from collections to support most recent python versions.

Most recent versions of python no longer allow "from collections import Hashable" but rather require "from collections.abc import Hashable". I've included a try-except block to take this into account.

### All Submissions

* [x] Is the code you are submitting your own work?
* [x] Have you followed the [contributing guidelines](https://github.com/ddbourgin/numpy-ml/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ddbourgin/numpy-ml/pulls) for the same update/change?

### New Model Submissions

* [x] Is the code you are submitting your own work?
* [x] Did you properly attribute the authors of any code you referenced?
* [x] Did you write unit tests for your new model?
* [x] Does your submission pass the unit tests?
* [x] Did you write documentation for your new model?
* [x] Have you formatted your code using the [black](https://black.now.sh/) deaults?

### Changes to Existing Models

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
