### PR TITLE
Fix shape mismatch error during backpropagation in MLP optimizer

### DIFF
--- a/numpy_ml/neural_nets/layers/layers.py
+++ b/numpy_ml/neural_nets/layers/layers.py
@@ -79,6 +79,9 @@ class LayerBase(ABC):
         optimizer. Flush all gradients once the update is complete.
         """
         assert self.trainable, "Layer is frozen"
+        self.optimizer = (
+            self.optimizer.copy() if self.optimizer.cur_step == 0 else self.optimizer
+        )  
         self.optimizer.step()
         for k, v in self.gradients.items():
             if k in self.parameters:


### PR DESCRIPTION
This submission addresses the issue tracked in #78.

**Root Cause**

In optimizers like Adam and SGD, the `self.cache` was shared among all layers, leading to a situation where the cache keys were simply `W` and `b`. As a result, when different layers attempted to update their parameters, they all referred to the same cache entries. This led to shape mismatches because the updates for different layers were not properly isolated.

For instance, the cache should have unique keys like `layer1-W`, `layer1-b`, `layer2-W`, etc., but instead, all parameters were using the same keys, resulting in conflicts during backpropagation.

**Solution**

The solution involved ensuring that each layer maintained its own cache. This was done by creating a deepcopy of the optimizer linked to each specific layer during its initialization. This way, each layer could independently manage its cache.

### All Submissions

* [x] Is the code you are submitting your own work?
* [x] Have you followed the [contributing guidelines](https://github.com/ddbourgin/numpy-ml/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ddbourgin/numpy-ml/pulls) for the same update/change?

### Changes to Existing Models

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
